### PR TITLE
pnpm won't build on less than node 18.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.8-alpine as base
+FROM node:18.12-alpine as base
 
 FROM base as builder
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM node:18.8-alpine
+FROM node:18.12-alpine
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
Fix for this error when building:

    ERROR: This version of pnpm requires at least Node.js v18.12
    The current version of Node.js is v18.8.0
    Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
    The command '/bin/sh -c pnpm i' returned a non-zero code: 1
    ERROR: Service 'payload' failed to build : Build failed